### PR TITLE
Fix undefined session bug when creating posts

### DIFF
--- a/src/app/api/posts/route.js
+++ b/src/app/api/posts/route.js
@@ -50,13 +50,13 @@ export const GET = async (req) => {
 
 // CREATE A POST
 export const POST = async (req) => {
-  // const session = await getAuthSession();
+  const session = await getAuthSession();
 
-  // if (!session) {
-  //   return new NextResponse(
-  //     JSON.stringify({ message: "Not Authenticated!" }, { status: 401 })
-  //   );
-  // }
+  if (!session) {
+    return new NextResponse(
+      JSON.stringify({ message: "Not Authenticated!" }, { status: 401 })
+    );
+  }
 
   try {
     const body = await req.json();

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,5 +1,6 @@
 import GithubProvider from "next-auth/providers/github";
 import GoogleProvider from "next-auth/providers/google";
+import { getServerSession } from "next-auth/next";
 
 export const authOptions = {
   providers: [
@@ -13,3 +14,7 @@ export const authOptions = {
     }),
   ],
 };
+
+export function getAuthSession() {
+  return getServerSession(authOptions);
+}


### PR DESCRIPTION
## Summary
- implement `getAuthSession` helper and use `getServerSession`
- require authentication in post creation API

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688d10398038833392bb9a53e2d22923